### PR TITLE
Add release and PR testing Github Actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,28 @@
+name: Test
+
+on: pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - "2.4"
+          - "2.5"
+          - "2.6"
+          - "2.7"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ${{ matrix.ruby }}
+      - name: Install dependencies
+        run: bundle install
+      - name: Build docs
+        run: bundle exec rake yard
+      - name: Run tests
+        run: bundle exec rake test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,8 +20,6 @@ jobs:
         with:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
-      - name: Install dependencies
-        run: bundle install
       - name: Build docs
         run: bundle exec rake yard
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Gem Release
+
+on:
+  create:
+    ref_type: tag
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.repository == 'voxpupuli/beaker-puppet'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Ruby 2.6
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+      - name: Build gem
+        run: gem build *.gemspec
+      - name: Setup credentials
+        run: |
+          mkdir -p ~/.gem
+          echo -e "---\n:rubygems_api_key: ${{ secrets.RUBYGEMS_AUTH_TOKEN }}" > ~/.gem/credentials
+          chmod 0600 ~/.gem/credentials
+      - name: Publish gem
+        run: gem push *.gem

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,16 +10,13 @@ jobs:
     if: github.repository == 'voxpupuli/beaker-puppet'
     steps:
       - uses: actions/checkout@v2
-      - name: Install Ruby 2.6
+      - name: Install Ruby 2.7
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: '2.7'
       - name: Build gem
         run: gem build *.gemspec
-      - name: Setup credentials
-        run: |
-          mkdir -p ~/.gem
-          echo -e "---\n:rubygems_api_key: ${{ secrets.RUBYGEMS_AUTH_TOKEN }}" > ~/.gem/credentials
-          chmod 0600 ~/.gem/credentials
       - name: Publish gem
         run: gem push *.gem
+        env:
+          GEM_HOST_API_KEY: '${{ secrets.RUBYGEMS_AUTH_TOKEN }}'

--- a/README.md
+++ b/README.md
@@ -80,10 +80,5 @@ Please refer to puppetlabs/beaker's [contributing](https://github.com/puppetlabs
 
 # Releasing
 
-To release new versions of beaker-puppet, please use the [jenkins job](https://cinext-jenkinsmaster-sre-prod-1.delivery.puppetlabs.net/job/qe_beaker-puppet_init-multijob_master/). This job
-lives on internal infrastructure.
-
-To run the job, click on `Build with Parameters` in the menu on the left. Make
-sure you check the box next to `PUBLIC` and enter the appropriate version. The
-version should adhere to semantic version standards. When in doubt, consult the
-maintainers of Beaker for guidance.
+To release the gem, update the version at `lib/beaker-puppet/version` then tag the repo with the
+corresponding version. Once tagged a Github Action will trigger which builds and publishes the gem.


### PR DESCRIPTION
This adds 2 Github Actions, copied from the Beaker repo. The first is a
release workflow that is triggered on tag to beaker-puppet, which
builds and publishes the beaker-puppet gem. The second is a per-PR
testing workflow that runs the spec tests.