### PR TITLE
(maint) Remove deprecated gem install flags

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -952,7 +952,7 @@ module Beaker
               on host, "echo '#{path_with_gem}' >> ~/.bashrc"
             end
 
-            gemflags = '--no-ri --no-rdoc --no-format-executable'
+            gemflags = '--no-document --no-format-executable'
 
             if opts[:facter_version]
               on host, "gem install facter -v'#{opts[:facter_version]}' #{gemflags}"

--- a/setup/git/000_EnvSetup.rb
+++ b/setup/git/000_EnvSetup.rb
@@ -145,6 +145,6 @@ step "Install bundler" do
   configure_gem_mirror(agents)
 
   agents.each do |host|
-    on host, "#{gem_command(host)} install bundler --no-ri --no-rdoc"
+    on host, "#{gem_command(host)} install bundler --no-document"
   end
 end


### PR DESCRIPTION
Ruby 2.7 ships with RubyGems 3, which removed the
previously deprecated --no-ri and --no-rdoc flags
in favor of --no-document.
The --no-document flag is available since RubyGems 2.

https://github.com/rubygems/rubygems/commit/0d22d6025ce2653ec9fb20a4e0745c79bda677da