### PR TITLE
(maint) Make latest the latest stable instead of nightly

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -1435,7 +1435,7 @@ module Beaker
         def install_puppetserver_on(host, opts = {})
           opts = sanitize_opts(opts)
 
-          # Default to installing latest from nightlies
+          # Default to installing latest
           opts[:version] ||= 'latest'
 
           # If inside the Puppet VPN, install from development builds.
@@ -1456,8 +1456,10 @@ module Beaker
           # here would be incorrect - that refers to FOSS puppet 3 only).
           host[:type] = :aio
 
-          if opts[:version] == 'latest' || opts[:nightlies]
-            release_stream += '-nightly' unless release_stream.end_with? "-nightly"
+          if opts[:version] == 'latest'
+            if opts[:nightlies]
+              release_stream += '-nightly' unless release_stream.end_with? "-nightly"
+            end
 
             # Since we have modified the collection, we don't want to pass `latest`
             # in to `install_package` as the version. That'll fail. Instead, if

--- a/lib/beaker-puppet/install_utils/puppet_utils.rb
+++ b/lib/beaker-puppet/install_utils/puppet_utils.rb
@@ -152,7 +152,7 @@ module Beaker
           result = on(host, 'puppetserver --version', accept_all_exit_codes: true)
           if result.exit_code.zero?
             matched = result.stdout.strip.scan(%r{\d+\.\d+\.\d+})
-            return matched.last
+            return matched.first
           end
           nil
         end

--- a/spec/beaker-puppet/install_utils/foss_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/foss_utils_spec.rb
@@ -1492,8 +1492,8 @@ describe ClassMixedWithDSLInstallUtils do
     let(:host) { make_host('master', platform: 'el-7-x86_64') }
 
     context 'with default arguments' do
-      it "installs the latest puppetserver from the default 'puppet-nightly' release stream" do
-        expect(subject).to receive(:install_puppetlabs_release_repo_on).with(host, 'puppet-nightly', include(nightly_yum_repo_url: "http://nightlies.puppet.com/yum"))
+      it "installs the latest puppetserver from the default 'puppet' release stream" do
+        expect(subject).to receive(:install_puppetlabs_release_repo_on).with(host, 'puppet', include(release_yum_repo_url: "http://yum.puppet.com"))
         expect(subject).to receive(:install_package).with(host, 'puppetserver', nil)
         subject.install_puppetserver_on(host)
       end

--- a/spec/beaker-puppet/install_utils/puppet_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/puppet_utils_spec.rb
@@ -137,6 +137,20 @@ describe ClassMixedWithDSLInstallUtils do
 
   end
 
+  describe '#puppetserver_version_on' do
+    it 'returns the tag on a released version' do
+      result = object_double(Beaker::Result.new({}, 'puppetserver --version'), :stdout => "puppetserver version: 6.13.0", :exit_code => 0)
+      expect(subject).to receive(:on).with(hosts.first, 'puppetserver --version', accept_all_exit_codes: true).and_return(result)
+      expect(subject.puppetserver_version_on(hosts.first)).to eq('6.13.0')
+    end
+
+    it 'returns the tag on a nightly version' do
+      result = object_double(Beaker::Result.new({}, 'puppetserver --version'), :stdout => "puppetserver version: 7.0.0.SNAPSHOT.2020.10.14T0512", :exit_code => 0)
+      expect(subject).to receive(:on).with(hosts.first, 'puppetserver --version', accept_all_exit_codes: true).and_return(result)
+      expect(subject.puppetserver_version_on(hosts.first)).to eq('7.0.0')
+    end
+  end
+
   describe '#puppet_collection_for' do
     it 'raises an error when given an invalid package' do
       expect { subject.puppet_collection_for(:foo, '5.5.4') }.to raise_error


### PR DESCRIPTION
Prior to this PR, if `install_puppetserver_on` was called without a version it would install the latest available nightly build.

This logic makes the use case of installing the latest *released* version unusable (i.e. from non-nightly collections), as the method
would always append `-nightly` to the collection if no version is passed.

As the `nightly` option can already be supplied to the method, change the logic to no longer assume the user wants a nightly build if they don't pass a version (or if `version: 'latest'`).

Currently, running `puppetserver_version_on` on a nightly build of puppetserver, assuming `puppetserver --version` returns something similar to:

`puppetserver version: 5.3.15.SNAPSHOT.2020.09.28T1639`

The method matches both `5.3.15` and `2020.09.28`, but returns the latter as the version, which is unusable. Return the first match instead of the last.

Did a quick check on these methods and it appears they are only used in the puppet_agent module (where I'm encountering this), so the chance of breaking unwanted stuff is minimal.