### PR TITLE
Fix Arch Linux support

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -419,6 +419,8 @@ module Beaker
                 install_puppet_agent_from_msi_on(host, opts)
               when /osx/
                 install_puppet_agent_from_dmg_on(host, opts)
+              when /archlinux/
+                install_puppet_from_pacman_on(host, opts)
               else
                 if opts[:default_action] == 'gem_install'
                   opts[:version] = opts[:puppet_gem_version]


### PR DESCRIPTION
Arch has a custom method to install the puppet agent. This needs to be
called, no matter if we want to install `puppet` or `puppet-agent`. Arch
Linux just has one puppet package in the repository and Puppet Inc. does
not provide custom packages/repos.