### PR TITLE
(maint) attempt to fix `puppet_collection_for`

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -1361,6 +1361,8 @@ module Beaker
             opts[:copy_base_local]    ||= File.join('tmp', 'repo_configs')
             opts[:copy_dir_external]  ||= host.external_copy_base
             opts[:puppet_collection] ||= puppet_collection_for(:puppet_agent, opts[:puppet_agent_version])
+            opts[:puppet_collection] = 'PC1' if opts[:puppet_collection] == 'pc1'
+
             add_role(host, 'aio') #we are installing agent, so we want aio role
             release_path = opts[:download_url]
             variant, version, arch, codename = host['platform'].to_array

--- a/lib/beaker-puppet/install_utils/puppet_utils.rb
+++ b/lib/beaker-puppet/install_utils/puppet_utils.rb
@@ -124,6 +124,8 @@ module Beaker
 
             return 'pc1' if x == pc1_x[package]
 
+            return 'pc1' if package == :puppet_agent && x > 4 && version_is_less(version, "5.5.4")
+
             # A y version >= 99 indicates a pre-release version of the next x release
             x += 1 if y >= 99
             "puppet#{x}" if x > 4

--- a/spec/beaker-puppet/install_utils/foss_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/foss_utils_spec.rb
@@ -1424,10 +1424,10 @@ describe ClassMixedWithDSLInstallUtils do
         subject.install_puppet_agent_pe_promoted_repo_on( host, opts )
       end
 
-      it 'sets correct file paths for agent version 1.x.x' do
+      it 'sets correct file paths for agent version < 5.5.4' do
         host['platform'] = platform
-        agentversion = '1.x.x'
-        collection = 'pc1'
+        agentversion = '5.3.3'
+        collection = 'PC1'
         opts = { :puppet_agent_version => "#{agentversion}" , :pe_promoted_builds_url => "#{downloadurl}"}
 
         expect(subject).to receive(:fetch_http_file).once.with(

--- a/spec/beaker-puppet/install_utils/puppet_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/puppet_utils_spec.rb
@@ -161,8 +161,10 @@ describe ClassMixedWithDSLInstallUtils do
         {
           '1.10.14'     => 'pc1',
           '1.10.x'      => 'pc1',
-          '5.3.1'       => 'puppet5',
-          '5.3.x'       => 'puppet5',
+          '5.3.1'       => 'pc1',
+          '5.3.x'       => 'pc1',
+          '5.5.3'       => 'pc1',
+          '5.5.4'       => 'puppet5',
           '5.99.0'      => 'puppet6',
           '6.1.99-foo'  => 'puppet6',
           '6.99.99'     => 'puppet7',


### PR DESCRIPTION
In PR https://github.com/voxpupuli/beaker-puppet/pull/149 a call to deprecated method `get_puppet_collection`
was replaced with a call `puppet_collection_for`. Unfortunatelly, the new method
does not have the same behavior for puppet_agent package.

This PR attempts to fix the issue