### PR TITLE
Create better puppet apply tmpfiles

### DIFF
--- a/lib/beaker-puppet/helpers/puppet_helpers.rb
+++ b/lib/beaker-puppet/helpers/puppet_helpers.rb
@@ -519,7 +519,7 @@ module Beaker
               puppet_apply_opts['ENV'] = opts[:environment]
             end
 
-            file_path = host.tmpfile('apply_manifest.pp')
+            file_path = host.tmpfile(%(apply_manifest_#{Time.now.strftime("%H%M%S%L")}.pp))
             create_remote_file(host, file_path, manifest + "\n")
 
             if host[:default_apply_opts].respond_to? :merge


### PR DESCRIPTION
Adds a date-based incremental portion to the /tmp/apply_manifest*.pp files so
that debugging is easier.

Prevously, you had a set of files that were not ordered by application time.
Now, you have a set of files that is ordered by application time which means
that a simple directory listing of /tmp will tell you which one executed last.