### PR TITLE
Add el8 support for install_puppet_on

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -303,7 +303,7 @@ module Beaker
             # run_in_parallel option includes install
             run_in_parallel = run_in_parallel? opts, @options, 'install'
             block_on hosts, { :run_in_parallel => run_in_parallel } do |host|
-              if host['platform'] =~ /el-(5|6|7)/
+              if host['platform'] =~ /el-(5|6|7|8)/
                 relver = $1
                 install_puppet_from_rpm_on(host, opts.merge(:release => relver, :family => 'el'))
               elsif host['platform'] =~ /fedora-(\d+)/

--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -303,12 +303,10 @@ module Beaker
             # run_in_parallel option includes install
             run_in_parallel = run_in_parallel? opts, @options, 'install'
             block_on hosts, { :run_in_parallel => run_in_parallel } do |host|
-              if host['platform'] =~ /el-(5|6|7|8)/
-                relver = $1
-                install_puppet_from_rpm_on(host, opts.merge(:release => relver, :family => 'el'))
-              elsif host['platform'] =~ /fedora-(\d+)/
-                relver = $1
-                install_puppet_from_rpm_on(host, opts.merge(:release => relver, :family => 'fedora'))
+              if host['platform'] =~ /(el|fedora)-(\d+)/
+                family = $1
+                relver = $2
+                install_puppet_from_rpm_on(host, opts.merge(:release => relver, :family => family))
               elsif host['platform'] =~ /(ubuntu|debian|cumulus|huaweios)/
                 install_puppet_from_deb_on(host, opts)
               elsif host['platform'] =~ /windows/


### PR DESCRIPTION
beaker has support for an `el-8-*` platform but the `install_puppet_on` function does not recognise this platform