### PR TITLE
(maint) Follow redirects when curling MSI

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -75,7 +75,7 @@ module Beaker
           # redhat-8-arm64 is provided from amazon
           return true if host.host_hash[:template] == 'redhat-8-arm64' && host.hostname =~ /.puppet.net$/
 
-          result = on(host, %(curl -fI "#{url}"), accept_all_exit_codes: true)
+          result = on(host, %(curl --location -fI "#{url}"), accept_all_exit_codes: true)
           return result.exit_code.zero?
         end
 
@@ -681,7 +681,7 @@ module Beaker
             if host.is_cygwin?
               # NOTE: it is critical that -o be before -O on Windows
               proxy = opts[:package_proxy] ? "-x #{opts[:package_proxy]} " : ''
-              on host, "curl #{proxy}-o \"#{msi_download_path}\" -O #{link}"
+              on host, "curl #{proxy}--location -o \"#{msi_download_path}\" -O #{link}"
 
               #Because the msi installer doesn't add Puppet to the environment path
               #Add both potential paths for simplicity

--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -681,7 +681,7 @@ module Beaker
             if host.is_cygwin?
               # NOTE: it is critical that -o be before -O on Windows
               proxy = opts[:package_proxy] ? "-x #{opts[:package_proxy]} " : ''
-              on host, "curl #{proxy}--location -o \"#{msi_download_path}\" -O #{link}"
+              on host, "curl #{proxy}--location --output \"#{msi_download_path}\" --remote-name #{link}"
 
               #Because the msi installer doesn't add Puppet to the environment path
               #Add both potential paths for simplicity

--- a/spec/beaker-puppet/install_utils/foss_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/foss_utils_spec.rb
@@ -341,7 +341,7 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'installs puppet on cygwin windows' do
       allow(subject).to receive(:link_exists?).and_return( true )
-      expect(subject).to receive(:on).with(winhost, "curl --location -o \"#{win_temp}\\puppet-3.7.1-x64.msi\" -O http://downloads.puppet.com/windows/puppet-3.7.1-x64.msi")
+      expect(subject).to receive(:on).with(winhost, "curl --location --output \"#{win_temp}\\puppet-3.7.1-x64.msi\" --remote-name http://downloads.puppet.com/windows/puppet-3.7.1-x64.msi")
       expect(subject).to receive(:on).with(winhost, " echo 'export PATH=$PATH:\"/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin\":\"/cygdrive/c/Program Files/Puppet Labs/Puppet/bin\"' > /etc/bash.bashrc ")
       expect(subject).to receive(:install_msi_on).with(winhost, "#{win_temp}\\puppet-3.7.1-x64.msi", {}, {:debug => nil})
 
@@ -350,7 +350,7 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'installs puppet on cygwin windows via proxy' do
       allow(subject).to receive(:link_exists?).and_return( true )
-      expect(subject).to receive(:on).with(winhost, "curl -x https://proxy.com --location -o \"#{win_temp}\\puppet-3.7.1-x64.msi\" -O http://downloads.puppet.com/windows/puppet-3.7.1-x64.msi")
+      expect(subject).to receive(:on).with(winhost, "curl -x https://proxy.com --location --output \"#{win_temp}\\puppet-3.7.1-x64.msi\" --remote-name http://downloads.puppet.com/windows/puppet-3.7.1-x64.msi")
       expect(subject).to receive(:on).with(winhost, " echo 'export PATH=$PATH:\"/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin\":\"/cygdrive/c/Program Files/Puppet Labs/Puppet/bin\"' > /etc/bash.bashrc ")
       expect(subject).to receive(:install_msi_on).with(winhost, "#{win_temp}\\puppet-3.7.1-x64.msi", {}, {:debug => nil})
 

--- a/spec/beaker-puppet/install_utils/foss_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/foss_utils_spec.rb
@@ -341,7 +341,7 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'installs puppet on cygwin windows' do
       allow(subject).to receive(:link_exists?).and_return( true )
-      expect(subject).to receive(:on).with(winhost, "curl -o \"#{win_temp}\\puppet-3.7.1-x64.msi\" -O http://downloads.puppet.com/windows/puppet-3.7.1-x64.msi")
+      expect(subject).to receive(:on).with(winhost, "curl --location -o \"#{win_temp}\\puppet-3.7.1-x64.msi\" -O http://downloads.puppet.com/windows/puppet-3.7.1-x64.msi")
       expect(subject).to receive(:on).with(winhost, " echo 'export PATH=$PATH:\"/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin\":\"/cygdrive/c/Program Files/Puppet Labs/Puppet/bin\"' > /etc/bash.bashrc ")
       expect(subject).to receive(:install_msi_on).with(winhost, "#{win_temp}\\puppet-3.7.1-x64.msi", {}, {:debug => nil})
 
@@ -350,7 +350,7 @@ describe ClassMixedWithDSLInstallUtils do
 
     it 'installs puppet on cygwin windows via proxy' do
       allow(subject).to receive(:link_exists?).and_return( true )
-      expect(subject).to receive(:on).with(winhost, "curl -x https://proxy.com -o \"#{win_temp}\\puppet-3.7.1-x64.msi\" -O http://downloads.puppet.com/windows/puppet-3.7.1-x64.msi")
+      expect(subject).to receive(:on).with(winhost, "curl -x https://proxy.com --location -o \"#{win_temp}\\puppet-3.7.1-x64.msi\" -O http://downloads.puppet.com/windows/puppet-3.7.1-x64.msi")
       expect(subject).to receive(:on).with(winhost, " echo 'export PATH=$PATH:\"/cygdrive/c/Program Files (x86)/Puppet Labs/Puppet/bin\":\"/cygdrive/c/Program Files/Puppet Labs/Puppet/bin\"' > /etc/bash.bashrc ")
       expect(subject).to receive(:install_msi_on).with(winhost, "#{win_temp}\\puppet-3.7.1-x64.msi", {}, {:debug => nil})
 


### PR DESCRIPTION
Add `--location` curl option, otherwise we save the redirect HTML page as the
msi, try to install that, and of course msiexec fails with 1620 since the
package is invalid.