### PR TITLE
Igrore files at the root level only

### DIFF
--- a/lib/beaker-puppet/install_utils/module_utils.rb
+++ b/lib/beaker-puppet/install_utils/module_utils.rb
@@ -15,8 +15,8 @@ module Beaker
 
         # The directories in the module directory that will not be scp-ed to the test system when using
         # `copy_module_to`
-        PUPPET_MODULE_INSTALL_IGNORE = ['.bundle', '.git', '.idea', '.vagrant', '.vendor', 'vendor', 'acceptance',
-                                        'bundle', 'spec', 'tests', 'log', '.svn', 'junit', 'pkg', 'example', 'tmp']
+        PUPPET_MODULE_INSTALL_IGNORE = ['/.bundle', '/.git', '/.idea', '/.vagrant', '/.vendor', '/vendor', '/acceptance',
+                                        '/bundle', '/spec', '/tests', '/log', '/.svn', '/junit', '/pkg', '/example', '/tmp']
 
         # Install the desired module on all hosts using either the PMT or a
         #   staging forge


### PR DESCRIPTION
Do not igrore these files at any level in the hierarchy, only at the
root of the copied data.
