### PR TITLE
(PA-4331) Add a step for updating Solaris CA Keystore

### DIFF
--- a/setup/common/003_solaris_cert_fix.rb
+++ b/setup/common/003_solaris_cert_fix.rb
@@ -1,0 +1,54 @@
+test_name 'Add digicert to solaris keystore'
+
+# Only need to run this on soliars 11, 11.2, and sparc
+skip_test 'No solaris 11 version that needed keystore updating' if ! hosts.any? { |host| host.platform=~ /solaris-11(\.2)?-(i386|sparc)/}
+
+DigiCert = <<-EOM
+-----BEGIN CERTIFICATE-----
+MIIFkDCCA3igAwIBAgIQBZsbV56OITLiOQe9p3d1XDANBgkqhkiG9w0BAQwFADBi
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+d3cuZGlnaWNlcnQuY29tMSEwHwYDVQQDExhEaWdpQ2VydCBUcnVzdGVkIFJvb3Qg
+RzQwHhcNMTMwODAxMTIwMDAwWhcNMzgwMTE1MTIwMDAwWjBiMQswCQYDVQQGEwJV
+UzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3d3cuZGlnaWNlcnQu
+Y29tMSEwHwYDVQQDExhEaWdpQ2VydCBUcnVzdGVkIFJvb3QgRzQwggIiMA0GCSqG
+SIb3DQEBAQUAA4ICDwAwggIKAoICAQC/5pBzaN675F1KPDAiMGkz7MKnJS7JIT3y
+ithZwuEppz1Yq3aaza57G4QNxDAf8xukOBbrVsaXbR2rsnnyyhHS5F/WBTxSD1If
+xp4VpX6+n6lXFllVcq9ok3DCsrp1mWpzMpTREEQQLt+C8weE5nQ7bXHiLQwb7iDV
+ySAdYyktzuxeTsiT+CFhmzTrBcZe7FsavOvJz82sNEBfsXpm7nfISKhmV1efVFiO
+DCu3T6cw2Vbuyntd463JT17lNecxy9qTXtyOj4DatpGYQJB5w3jHtrHEtWoYOAMQ
+jdjUN6QuBX2I9YI+EJFwq1WCQTLX2wRzKm6RAXwhTNS8rhsDdV14Ztk6MUSaM0C/
+CNdaSaTC5qmgZ92kJ7yhTzm1EVgX9yRcRo9k98FpiHaYdj1ZXUJ2h4mXaXpI8OCi
+EhtmmnTK3kse5w5jrubU75KSOp493ADkRSWJtppEGSt+wJS00mFt6zPZxd9LBADM
+fRyVw4/3IbKyEbe7f/LVjHAsQWCqsWMYRJUadmJ+9oCw++hkpjPRiQfhvbfmQ6QY
+uKZ3AeEPlAwhHbJUKSWJbOUOUlFHdL4mrLZBdd56rF+NP8m800ERElvlEFDrMcXK
+chYiCd98THU/Y+whX8QgUWtvsauGi0/C1kVfnSD8oR7FwI+isX4KJpn15GkvmB0t
+9dmpsh3lGwIDAQABo0IwQDAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIB
+hjAdBgNVHQ4EFgQU7NfjgtJxXWRM3y5nP+e6mK4cD08wDQYJKoZIhvcNAQEMBQAD
+ggIBALth2X2pbL4XxJEbw6GiAI3jZGgPVs93rnD5/ZpKmbnJeFwMDF/k5hQpVgs2
+SV1EY+CtnJYYZhsjDT156W1r1lT40jzBQ0CuHVD1UvyQO7uYmWlrx8GnqGikJ9yd
++SeuMIW59mdNOj6PWTkiU0TryF0Dyu1Qen1iIQqAyHNm0aAFYF/opbSnr6j3bTWc
+fFqK1qI4mfN4i/RN0iAL3gTujJtHgXINwBQy7zBZLq7gcfJW5GqXb5JQbZaNaHqa
+sjYUegbyJLkJEVDXCLG4iXqEI2FCKeWjzaIgQdfRnGTZ6iahixTXTBmyUEFxPT9N
+cCOGDErcgdLMMpSEDQgJlxxPwO5rIHQw0uA5NBCFIRUBCOhVMt5xSdkoF1BN5r5N
+0XWs0Mr7QbhDparTwwVETyw2m+L64kW4I1NsBm9nVX9GtUw/bihaeSbSpKhil9Ie
+4u1Ki7wb/UdKDd9nZn6yW0HQO+T0O/QEY+nvwlQAUaCKKsnOeMzV6ocEGLPOr0mI
+r/OSmbaz5mEP0oUA51Aa5BuVnRmhuZyxm7EAHu/QD09CbMkKvO5D+jpxpchNJqU1
+/YldvIViHTLSoCtU7ZpXwdv6EM8Zt4tKG48BtieVU+i2iW1bvGjUI+iLUaJW+fCm
+gKDWHrO8Dw9TdSmq6hN35N6MgSGtBxBHEa2HPQfRdbzP82Z+
+-----END CERTIFICATE-----
+EOM
+
+hosts.each do |host|
+  create_remote_file(host, "DigiCertTrustedRootG4.crt.pem", DigiCert)
+  on(host, 'chmod a+r /root/DigiCertTrustedRootG4.crt.pem')
+  on(host, 'cp -p /root/DigiCertTrustedRootG4.crt.pem /etc/certs/CA/')
+  on(host, 'rm /root/DigiCertTrustedRootG4.crt.pem')
+  on(host, '/usr/sbin/svcadm restart /system/ca-certificates')
+  timeout = 60
+  counter = 0
+  while on(host, 'svcs -x ca-certificates').output !~ /State: online/ do
+    raise 'ca-certificates services failed start up' if counter > timeout
+    sleep 5
+    counter = counter + 5
+  end
+end

--- a/tasks/ci.rake
+++ b/tasks/ci.rake
@@ -311,6 +311,7 @@ def pre_suites(type)
   when :aio
     [
       "#{beaker_root}/setup/common/000-delete-puppet-when-none.rb",
+      "#{beaker_root}/setup/common/003_solaris_cert_fix.rb",
       "#{beaker_root}/setup/aio/010_Install_Puppet_Agent.rb",
       "#{beaker_root}/setup/common/011_Install_Puppet_Server.rb",
       "#{beaker_root}/setup/common/012_Finalize_Installs.rb",


### PR DESCRIPTION
A recent change to the way puppet-agent is packaged requires versions
of Solaris that are older then 11.3 to install a new cert.
The Puppet VM images for Solaris for 11, 11.2, and Solaris-Sparc need to
be updated to include the updating of the keystore. That will take some
time to accomplish, as a work around we are going to update the keystore
as part of a pre-suite.
Once we update our vmpooler images for the three versions we can remove
the pre-suite step.
Any other OS will skip the pre-suite step.