### PR TITLE
(PA-4332) Changes download links to HTTPS

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_defaults.rb
+++ b/lib/beaker-puppet/install_utils/foss_defaults.rb
@@ -8,17 +8,17 @@ module Beaker
 
         #Here be the default download URLs
         FOSS_DEFAULT_DOWNLOAD_URLS = {
-          :win_download_url         => "http://downloads.puppet.com/windows",
-          :mac_download_url         => "http://downloads.puppet.com/mac",
-          :pe_promoted_builds_url   => "http://pm.puppet.com",
-          :release_apt_repo_url     => "http://apt.puppet.com",
-          :release_yum_repo_url     => "http://yum.puppet.com",
-          :nightly_builds_url       => "http://nightlies.puppet.com",
-          :nightly_apt_repo_url     => "http://nightlies.puppet.com/apt",
-          :nightly_yum_repo_url     => "http://nightlies.puppet.com/yum",
-          :nightly_win_download_url => "http://nightlies.puppet.com/downloads/windows",
-          :nightly_mac_download_url => "http://nightlies.puppet.com/downloads/mac",
-          :dev_builds_url           => "http://builds.delivery.puppetlabs.net",
+          :win_download_url         => "https://downloads.puppet.com/windows",
+          :mac_download_url         => "https://downloads.puppet.com/mac",
+          :pe_promoted_builds_url   => "https://pm.puppet.com",
+          :release_apt_repo_url     => "https://apt.puppet.com",
+          :release_yum_repo_url     => "https://yum.puppet.com",
+          :nightly_builds_url       => "https://nightlies.puppet.com",
+          :nightly_apt_repo_url     => "https://nightlies.puppet.com/apt",
+          :nightly_yum_repo_url     => "https://nightlies.puppet.com/yum",
+          :nightly_win_download_url => "https://nightlies.puppet.com/downloads/windows",
+          :nightly_mac_download_url => "https://nightlies.puppet.com/downloads/mac",
+          :dev_builds_url           => "https://builds.delivery.puppetlabs.net",
         }
 
         #Here be the pathing and default values for FOSS installs

--- a/lib/beaker-puppet/install_utils/puppet5.rb
+++ b/lib/beaker-puppet/install_utils/puppet5.rb
@@ -7,7 +7,7 @@ module Beaker
         include Beaker::DSL::InstallUtils::FOSSDefaults
 
         # Base URL for internal Puppet Inc. builds
-        DEFAULT_DEV_BUILDS_URL = 'http://builds.delivery.puppetlabs.net'
+        DEFAULT_DEV_BUILDS_URL = 'https://builds.delivery.puppetlabs.net'
 
         # grab build json from the builds server
         #

--- a/spec/beaker-puppet/install_utils/foss_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/foss_utils_spec.rb
@@ -1493,7 +1493,7 @@ describe ClassMixedWithDSLInstallUtils do
 
     context 'with default arguments' do
       it "installs the latest puppetserver from the default 'puppet' release stream" do
-        expect(subject).to receive(:install_puppetlabs_release_repo_on).with(host, 'puppet', include(release_yum_repo_url: "http://yum.puppet.com"))
+        expect(subject).to receive(:install_puppetlabs_release_repo_on).with(host, 'puppet', include(release_yum_repo_url: "https://yum.puppet.com"))
         expect(subject).to receive(:install_package).with(host, 'puppetserver', nil)
         subject.install_puppetserver_on(host)
       end


### PR DESCRIPTION
We are encountering some firewall issues due to download links
to builds.delivery.puppetlabs.net going over HTTP instead of
HTTPS. This changes the builds links to HTTPS along with other
download URLs (e.g. nightlies, yum, etc.).