### PR TITLE
(maint) Adds CA to Solaris 11 SPARC setup

### DIFF
--- a/setup/common/003_solaris_cert_fix.rb
+++ b/setup/common/003_solaris_cert_fix.rb
@@ -38,19 +38,57 @@ gKDWHrO8Dw9TdSmq6hN35N6MgSGtBxBHEa2HPQfRdbzP82Z+
 -----END CERTIFICATE-----
 EOM
 
+USERTrust = <<-EOM
+-----BEGIN CERTIFICATE-----
+MIIF3jCCA8agAwIBAgIQAf1tMPyjylGoG7xkDjUDLTANBgkqhkiG9w0BAQwFADCBiDELMAkGA1UE
+BhMCVVMxEzARBgNVBAgTCk5ldyBKZXJzZXkxFDASBgNVBAcTC0plcnNleSBDaXR5MR4wHAYDVQQK
+ExVUaGUgVVNFUlRSVVNUIE5ldHdvcmsxLjAsBgNVBAMTJVVTRVJUcnVzdCBSU0EgQ2VydGlmaWNh
+dGlvbiBBdXRob3JpdHkwHhcNMTAwMjAxMDAwMDAwWhcNMzgwMTE4MjM1OTU5WjCBiDELMAkGA1UE
+BhMCVVMxEzARBgNVBAgTCk5ldyBKZXJzZXkxFDASBgNVBAcTC0plcnNleSBDaXR5MR4wHAYDVQQK
+ExVUaGUgVVNFUlRSVVNUIE5ldHdvcmsxLjAsBgNVBAMTJVVTRVJUcnVzdCBSU0EgQ2VydGlmaWNh
+dGlvbiBBdXRob3JpdHkwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQCAEmUXNg7D2wiz
+0KxXDXbtzSfTTK1Qg2HiqiBNCS1kCdzOiZ/MPans9s/B3PHTsdZ7NygRK0faOca8Ohm0X6a9fZ2j
+Y0K2dvKpOyuR+OJv0OwWIJAJPuLodMkYtJHUYmTbf6MG8YgYapAiPLz+E/CHFHv25B+O1ORRxhFn
+RghRy4YUVD+8M/5+bJz/Fp0YvVGONaanZshyZ9shZrHUm3gDwFA66Mzw3LyeTP6vBZY1H1dat//O
++T23LLb2VN3I5xI6Ta5MirdcmrS3ID3KfyI0rn47aGYBROcBTkZTmzNg95S+UzeQc0PzMsNT79uq
+/nROacdrjGCT3sTHDN/hMq7MkztReJVni+49Vv4M0GkPGw/zJSZrM233bkf6c0Plfg6lZrEpfDKE
+Y1WJxA3Bk1QwGROs0303p+tdOmw1XNtB1xLaqUkL39iAigmTYo61Zs8liM2EuLE/pDkP2QKe6xJM
+lXzzawWpXhaDzLhn4ugTncxbgtNMs+1b/97lc6wjOy0AvzVVdAlJ2ElYGn+SNuZRkg7zJn0cTRe8
+yexDJtC/QV9AqURE9JnnV4eeUB9XVKg+/XRjL7FQZQnmWEIuQxpMtPAlR1n6BB6T1CZGSlCBst6+
+eLf8ZxXhyVeEHg9j1uliutZfVS7qXMYoCAQlObgOK6nyTJccBz8NUvXt7y+CDwIDAQABo0IwQDAd
+BgNVHQ4EFgQUU3m/WqorSs9UgOHYm8Cd8rIDZsswDgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQF
+MAMBAf8wDQYJKoZIhvcNAQEMBQADggIBAFzUfA3P9wF9QZllDHPFUp/L+M+ZBn8b2kMVn54CVVeW
+FPFSPCeHlCjtHzoBN6J2/FNQwISbxmtOuowhT6KOVWKR82kV2LyI48SqC/3vqOlLVSoGIG1VeCkZ
+7l8wXEskEVX/JJpuXior7gtNn3/3ATiUFJVDBwn7YKnuHKsSjKCaXqeYalltiz8I+8jRRa8YFWSQ
+Eg9zKC7F4iRO/Fjs8PRF/iKz6y+O0tlFYQXBl2+odnKPi4w2r78NBc5xjeambx9spnFixdjQg3IM
+8WcRiQycE0xyNN+81XHfqnHd4blsjDwSXWXavVcStkNr/+XeTWYRUc+ZruwXtuhxkYzeSf7dNXGi
+FSeUHM9h4ya7b6NnJSFd5t0dCy5oGzuCr+yDZ4XUmFF0sbmZgIn/f3gZXHlKYC6SQK5MNyosycdi
+yA5d9zZbyuAlJQG03RoHnHcAP9Dc1ew91Pq7P8yF1m9/qS3fuQL39ZeatTXaw2ewh0qpKJ4jjv9c
+J2vhsE/zB+4ALtRZh8tSQZXq9EfX7mRBVXyNWQKV3WKdwrnuWih0hKWbt5DHDAff9Yk2dDLWKMGw
+sAvgnEzDHNb842m1R0aBL6KCq9NjRHDEjf8tM7qtj3u1cIiuPhnPQCjY/MiQu12ZIvVS5ljFH4gx
+Q+6IHdfGjjxDah2nGN59PRbxYvnKkKj9
+-----END CERTIFICATE-----
+EOM
+
 hosts.each do |host|
-  if host.platform=~ /solaris-11(\.2)?-(i386|sparc)/
-    create_remote_file(host, "DigiCertTrustedRootG4.crt.pem", DigiCert)
-    on(host, 'chmod a+r /root/DigiCertTrustedRootG4.crt.pem')
-    on(host, 'cp -p /root/DigiCertTrustedRootG4.crt.pem /etc/certs/CA/')
-    on(host, 'rm /root/DigiCertTrustedRootG4.crt.pem')
-    on(host, '/usr/sbin/svcadm restart /system/ca-certificates')
-    timeout = 60
-    counter = 0
-    while on(host, 'svcs -x ca-certificates').output !~ /State: online/ do
-      raise 'ca-certificates services failed start up' if counter > timeout
-      sleep 5
-      counter = counter + 5
-    end
+  create_remote_file(host, "DigiCertTrustedRootG4.crt.pem", DigiCert)
+  on(host, 'chmod a+r /root/DigiCertTrustedRootG4.crt.pem')
+  on(host, 'cp -p /root/DigiCertTrustedRootG4.crt.pem /etc/certs/CA/')
+  on(host, 'rm /root/DigiCertTrustedRootG4.crt.pem')
+
+  if host.platform=~ /solaris-11-sparc/
+    create_remote_file(host, "USERTrust_RSA_Certification_Authority.pem", USERTrust)
+    on(host, 'chmod a+r /root/USERTrust_RSA_Certification_Authority.pem')
+    on(host, 'cp -p /root/USERTrust_RSA_Certification_Authority.pem /etc/certs/CA/')
+    on(host, 'rm /root/USERTrust_RSA_Certification_Authority.pem')
+  end
+
+  on(host, '/usr/sbin/svcadm restart /system/ca-certificates')
+  timeout = 60
+  counter = 0
+  while on(host, 'svcs -x ca-certificates').output !~ /State: online/ do
+    raise 'ca-certificates services failed start up' if counter > timeout
+    sleep 5
+    counter = counter + 5
   end
 end


### PR DESCRIPTION
Solaris 11 SPARC is currently missing the CA for USERTrust,
which is the root CA that Puppet's current SSL vendor, Gandi,
uses.

Missing this root CA causes an error with `curl`: "(60) SSL
certificate problem: unable to get local issuer certificate"

This adds that cert in an existing setup step.