### PR TITLE
(maint) Fixes Solaris cert setup step

### DIFF
--- a/setup/common/003_solaris_cert_fix.rb
+++ b/setup/common/003_solaris_cert_fix.rb
@@ -71,6 +71,7 @@ Q+6IHdfGjjxDah2nGN59PRbxYvnKkKj9
 EOM
 
 hosts.each do |host|
+  next unless host.platform =~ /solaris-11(\.2)?-(i386|sparc)/ 
   create_remote_file(host, "DigiCertTrustedRootG4.crt.pem", DigiCert)
   on(host, 'chmod a+r /root/DigiCertTrustedRootG4.crt.pem')
   on(host, 'cp -p /root/DigiCertTrustedRootG4.crt.pem /etc/certs/CA/')


### PR DESCRIPTION
I mistakenly changed the logic in the Solaris certificate setup
step to include all machines. This commit adds logic to constrain
the Solaris certificate setup step to only run for Solaris 11
machines.