### PR TITLE
(ITSYS-2543) Adds workaround for EL8 PPCLE

### DIFF
--- a/setup/common/005_redhat_subscription_fix.rb
+++ b/setup/common/005_redhat_subscription_fix.rb
@@ -1,0 +1,10 @@
+test_name 'Refresh Red Hat 8 subscription repository'
+
+# Only need to run this on Red Hat Enterprise Linux 8 on little-endian PowerPC
+skip_test 'Not Red Hat 8 PPCle' if ! hosts.any? { |host| host.platform == 'el-8-ppc64le' }
+
+hosts.each do |host|
+  next unless host.platform == 'el-8-ppc64le'
+
+  on(host, '/usr/sbin/subscription-manager repos --disable rhel-8-for-ppc64le-baseos-rpms && /usr/sbin/subscription-manager repos --enable rhel-8-for-ppc64le-baseos-rpms')
+end

--- a/tasks/ci.rake
+++ b/tasks/ci.rake
@@ -317,6 +317,7 @@ def pre_suites(type)
     [
       "#{beaker_root}/setup/common/000-delete-puppet-when-none.rb",
       "#{beaker_root}/setup/common/003_solaris_cert_fix.rb",
+      "#{beaker_root}/setup/common/005_redhat_subscription_fix.rb",
       "#{beaker_root}/setup/aio/010_Install_Puppet_Agent.rb",
       "#{beaker_root}/setup/common/011_Install_Puppet_Server.rb",
       "#{beaker_root}/setup/common/012_Finalize_Installs.rb",


### PR DESCRIPTION
We are consistently encountering an issue with RedHat Enterprise
Linux 8 on little-endian PowerPC where yum/dnf cannot fetch
repository metadata due to a perceived subscription issue.

This commit disables then reenables that repository, which seems
to work around the issue.

See https://access.redhat.com/discussions/4656371#comment-1769061