### PR TITLE
Fix DigiCert root cert to match fully patched Solaris 11.4

### DIFF
--- a/setup/common/003_solaris_cert_fix.rb
+++ b/setup/common/003_solaris_cert_fix.rb
@@ -72,10 +72,10 @@ EOM
 
 hosts.each do |host|
   next unless host.platform =~ /solaris-11(\.2)?-(i386|sparc)/ 
-  create_remote_file(host, "DigiCertTrustedRootG4.crt.pem", DigiCert)
-  on(host, 'chmod a+r /root/DigiCertTrustedRootG4.crt.pem')
-  on(host, 'cp -p /root/DigiCertTrustedRootG4.crt.pem /etc/certs/CA/')
-  on(host, 'rm /root/DigiCertTrustedRootG4.crt.pem')
+  create_remote_file(host, "DigiCert_Trusted_Root_G4.pem", DigiCert)
+  on(host, 'chmod a+r /root/DigiCert_Trusted_Root_G4.pem')
+  on(host, 'cp -p /root/DigiCert_Trusted_Root_G4.pem /etc/certs/CA/')
+  on(host, 'rm /root/DigiCert_Trusted_Root_G4.pem')
 
   if host.platform=~ /solaris-11-sparc/
     create_remote_file(host, "USERTrust_RSA_Certification_Authority.pem", USERTrust)


### PR DESCRIPTION
The DigiCert root CA G4 cert is named `DigiCert_Trusted_Root_G4.pem` on a fully patched Solaris 11.4 system. This resolves a duplicate certificate error after restarting ca-certificates.