### PR TITLE
(maint) Call `exist?` instead of `exists?`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,9 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 gemspec
 
 def location_for(place, fake_version = nil)
-  if place =~ /^(git:[^#]*)#(.*)/
+  if place.is_a?(String) && place =~ /^(git:[^#]*)#(.*)/
     [fake_version, { :git => $1, :branch => $2, :require => false }].compact
-  elsif place =~ /^file:\/\/(.*)/
+  elsif place.is_a?(String) && place =~ /^file:\/\/(.*)/
     ['>= 0', { :path => File.expand_path($1), :require => false }]
   else
     [place, { :require => false }]

--- a/Rakefile
+++ b/Rakefile
@@ -152,7 +152,7 @@ Run the puppet beaker acceptance tests on a base system (no install).
 
       def self.get_options(file_path)
         puts "Attempting to merge config file: #{file_path}"
-        if File.exists? file_path
+        if File.exist? file_path
           options = eval(File.read(file_path), binding)
         else
           puts "No options file found at #{File.expand_path(file_path)}... skipping"

--- a/lib/beaker-puppet/install_utils/module_utils.rb
+++ b/lib/beaker-puppet/install_utils/module_utils.rb
@@ -173,7 +173,7 @@ module Beaker
         #
         # @return [String,nil]
         def parse_for_moduleroot(possible_module_directory)
-          if File.exists?("#{possible_module_directory}/Modulefile") || File.exists?("#{possible_module_directory}/metadata.json")
+          if File.exist?("#{possible_module_directory}/Modulefile") || File.exist?("#{possible_module_directory}/metadata.json")
             possible_module_directory
           elsif possible_module_directory === '/'
             logger.error "At root, can't parse for another directory"
@@ -190,14 +190,14 @@ module Beaker
         # @return [String] module name
         def parse_for_modulename(root_module_dir)
           author_name, module_name = nil, nil
-          if File.exists?("#{root_module_dir}/metadata.json")
+          if File.exist?("#{root_module_dir}/metadata.json")
             logger.debug "Attempting to parse Modulename from metadata.json"
             module_json = JSON.parse(File.read "#{root_module_dir}/metadata.json")
             if(module_json.has_key?('name'))
               author_name, module_name = get_module_name(module_json['name'])
             end
           end
-          if !module_name && File.exists?("#{root_module_dir}/Modulefile")
+          if !module_name && File.exist?("#{root_module_dir}/Modulefile")
             logger.debug "Attempting to parse Modulename from Modulefile"
             if /^name\s+'?(\w+-\w+)'?\s*$/i.match(File.read("#{root_module_dir}/Modulefile"))
               author_name, module_name = get_module_name(Regexp.last_match[1])

--- a/spec/beaker-puppet/install_utils/module_utils_spec.rb
+++ b/spec/beaker-puppet/install_utils/module_utils_spec.rb
@@ -158,7 +158,7 @@ describe ClassMixedWithDSLInstallUtils do
           expect( subject).to_not receive(:parse_for_modulename)
         end
 
-        allow( File ).to receive(:exists?).with(any_args()).and_return(false)
+        allow( File ).to receive(:exist?).with(any_args()).and_return(false)
         allow( File ).to receive(:directory?).with(any_args()).and_return(false)
 
         expect( subject ).to receive(:scp_to).with(host,source, File.dirname(target), {:ignore => ignore_list})
@@ -295,15 +295,15 @@ describe ClassMixedWithDSLInstallUtils do
   describe 'parse_for_modulename' do
     directory = '/testfilepath/myname-testmodule'
     it 'should return name from metadata.json' do
-      allow( File ).to receive(:exists?).with("#{directory}/metadata.json").and_return(true)
+      allow( File ).to receive(:exist?).with("#{directory}/metadata.json").and_return(true)
       allow( File ).to receive(:read).with("#{directory}/metadata.json").and_return(" {\"name\":\"myname-testmodule\"} ")
       expect( subject.logger ).to receive(:debug).with("Attempting to parse Modulename from metadata.json")
       expect(subject.logger).to_not receive(:debug).with('Unable to determine name, returning null')
       expect(subject.parse_for_modulename(directory)).to eq(['myname', 'testmodule'])
     end
     it 'should return name from Modulefile' do
-      allow( File ).to receive(:exists?).with("#{directory}/metadata.json").and_return(false)
-      allow( File ).to receive(:exists?).with("#{directory}/Modulefile").and_return(true)
+      allow( File ).to receive(:exist?).with("#{directory}/metadata.json").and_return(false)
+      allow( File ).to receive(:exist?).with("#{directory}/Modulefile").and_return(true)
       allow( File ).to receive(:read).with("#{directory}/Modulefile").and_return("name    'myname-testmodule'  \nauthor   'myname'")
       expect( subject.logger ).to receive(:debug).with("Attempting to parse Modulename from Modulefile")
       expect(subject.logger).to_not receive(:debug).with("Unable to determine name, returning null")
@@ -315,16 +315,16 @@ describe ClassMixedWithDSLInstallUtils do
     directory = '/testfilepath/myname-testmodule'
     describe 'stops searching when either' do
       it 'finds a Modulefile' do
-        allow( File ).to receive(:exists?).and_return(false)
-        allow( File ).to receive(:exists?).with("#{directory}/Modulefile").and_return(true)
+        allow( File ).to receive(:exist?).and_return(false)
+        allow( File ).to receive(:exist?).with("#{directory}/Modulefile").and_return(true)
 
         expect( subject.logger ).to_not receive(:debug).with("At root, can't parse for another directory")
         expect( subject.logger ).to receive(:debug).with("No Modulefile or metadata.json found at #{directory}/acceptance, moving up")
         expect(subject.parse_for_moduleroot("#{directory}/acceptance")).to eq(directory)
       end
       it 'finds a metadata.json file' do
-        allow( File ).to receive(:exists?).and_return(false)
-        allow( File ).to receive(:exists?).with("#{directory}/metadata.json").and_return(true)
+        allow( File ).to receive(:exist?).and_return(false)
+        allow( File ).to receive(:exist?).with("#{directory}/metadata.json").and_return(true)
 
         expect( subject.logger ).to_not receive(:debug).with("At root, can't parse for another directory")
         expect( subject.logger ).to receive(:debug).with("No Modulefile or metadata.json found at #{directory}/acceptance, moving up")
@@ -332,7 +332,7 @@ describe ClassMixedWithDSLInstallUtils do
       end
     end
     it 'should recersively go up the directory to find the module files' do
-      allow( File ).to receive(:exists?).and_return(false)
+      allow( File ).to receive(:exist?).and_return(false)
       expect( subject.logger ).to receive(:debug).with("No Modulefile or metadata.json found at #{directory}, moving up")
       expect( subject.logger ).to receive(:error).with("At root, can't parse for another directory")
       expect(subject.parse_for_moduleroot(directory)).to eq(nil)

--- a/tasks/ci.rake
+++ b/tasks/ci.rake
@@ -170,7 +170,7 @@ namespace :ci do
         end
       end
 
-    if File.exists?(hosts)
+    if File.exist?(hosts)
       ENV['HOSTS'] = hosts
     else
       hosts_file = "tmp/#{hosts}-#{SecureRandom.uuid}.yaml"


### PR DESCRIPTION
The `exists?` method has long been deprecated and has been officially removed as of Ruby 3.2.0.