### PR TITLE
configure defaults on FreeBSD

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -720,8 +720,8 @@ module Beaker
 
           block_on hosts do |host|
             host.install_package("sysutils/puppet7")
+            configure_type_defaults_on( host )
           end
-
         end
         alias_method :install_puppet_from_freebsd_ports, :install_puppet_from_freebsd_ports_on
 


### PR DESCRIPTION
without this the data from foss_defaults is not properly loaded, leading to errors like:

    Beaker::Host::CommandFailure:
      Host 'freebsd12-64-1' exited with 64 running:
       mkdir -p
      Last 100 lines of output were:
      	usage: mkdir [-pv] [-m mode] directory_name ...

    # ./vendor/bundle/ruby/3.1.0/gems/beaker-4.39.0/lib/beaker/host.rb:396:in `exec'
    # ./vendor/bundle/ruby/3.1.0/gems/beaker-4.39.0/lib/beaker/host/unix/exec.rb:152:in `mkdir_p'
    # ./vendor/bundle/ruby/3.1.0/bundler/gems/beaker-puppet-c27c768fb186/lib/beaker-puppet/install_utils/foss_utils.rb:341:in `block in install_puppet_on'
    # ./vendor/bundle/ruby/3.1.0/gems/beaker-4.39.0/lib/beaker/shared/host_manager.rb:129:in `run_block_on'
    # ./vendor/bundle/ruby/3.1.0/gems/beaker-4.39.0/lib/beaker/dsl/patterns.rb:37:in `block_on'
    # ./vendor/bundle/ruby/3.1.0/bundler/gems/beaker-puppet-c27c768fb186/lib/beaker-puppet/install_utils/foss_utils.rb:306:in `install_puppet_on'
    # ./vendor/bundle/ruby/3.1.0/gems/beaker-puppet_install_helper-0.9.8/lib/beaker/puppet_install_helper.rb:49:in `block in run_puppet_install_helper_on'
    # ./vendor/bundle/ruby/3.1.0/gems/beaker-puppet_install_helper-0.9.8/lib/beaker/puppet_install_helper.rb:43:in `each'
    # ./vendor/bundle/ruby/3.1.0/gems/beaker-puppet_install_helper-0.9.8/lib/beaker/puppet_install_helper.rb:43:in `run_puppet_install_helper_on'
    # ./vendor/bundle/ruby/3.1.0/gems/beaker-puppet_install_helper-0.9.8/lib/beaker/puppet_install_helper.rb:8:in `run_puppet_install_helper'
    # ./vendor/bundle/ruby/3.1.0/gems/voxpupuli-acceptance-1.2.0/lib/voxpupuli/acceptance/spec_helper_acceptance.rb:24:in `configure_beaker'
    # ./spec/spec_helper_acceptance.rb:7:in `<top (required)>'
    # ./spec/acceptance/mosquitto_spec.rb:3:in `require'
    # ./spec/acceptance/mosquitto_spec.rb:3:in `<top (required)>'