### PR TITLE
Drop in-parallel dependency

### DIFF
--- a/beaker-puppet.gemspec
+++ b/beaker-puppet.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |s|
 
   # Run time dependencies
   s.add_runtime_dependency 'beaker', '~> 4.1'
-  s.add_runtime_dependency 'in-parallel', '>= 0.1', '< 2.0'
   s.add_runtime_dependency 'oga'
 
 end


### PR DESCRIPTION
Beaker itself depends on this. While in the tests it is used, we can rely on Beaker to specify the dependency.