### PR TITLE
Loosen expectations while attempting to delete puppet related files

### DIFF
--- a/lib/beaker-puppet/install_utils/foss_utils.rb
+++ b/lib/beaker-puppet/install_utils/foss_utils.rb
@@ -1518,7 +1518,10 @@ module Beaker
             end
 
             # delete any residual files
-            on(host, 'find / -name "*puppet*" -print | xargs rm -rf')
+            result = on(host, 'find / -name "*puppet*" -print | xargs rm -rf', accept_all_exit_codes: true)
+            unless result.exit_code == 0
+              logger.notify("Attempt to clean residual puppet files errored, but can maybe be ignored.\n #{result.stderr}")
+            end
           end
         end
 


### PR DESCRIPTION
In the Perforce/Puppet infrastructure, certain OS images have *puppet* in the file system that aren't modifiable. Since this is just a sort of best effort to remove puppet related files, we should loosen the expectations and notify in the log if something goes awry, but still continue execution.