### PR TITLE
(PA-8312) Skip gem source add for Solaris & AIX

### DIFF
--- a/setup/common/012_Finalize_Installs.rb
+++ b/setup/common/012_Finalize_Installs.rb
@@ -21,5 +21,13 @@ step 'Verify host times' do
 end
 
 step 'Configure gem mirror' do
-  configure_gem_mirror(hosts)
+  # Skip if RELEASE_STREAM is 'puppet9' and platform is aix or solaris
+  # Issue with Rubygems's SafeMarshal see: PA-8312
+  release_stream = ENV.fetch('RELEASE_STREAM')
+  skip_platforms = /aix|solaris/i
+  if release_stream == 'puppet9' && hosts.any? { |host| host['platform'] =~ skip_platforms }
+    logger.info 'Skipping configure_gem_mirror for puppet9 on aix/solaris, issue with rubygems 4.0'
+  else
+    configure_gem_mirror(hosts)
+  end
 end


### PR DESCRIPTION
After installing skip the gem source add part because we're running into memory issues and crashing. See PA-8312 for details.