### PR TITLE
(maint) Return nil when ENV does not contain "RELEASE_STREAM"

### DIFF
--- a/setup/common/012_Finalize_Installs.rb
+++ b/setup/common/012_Finalize_Installs.rb
@@ -23,7 +23,7 @@ end
 step 'Configure gem mirror' do
   # Skip if RELEASE_STREAM is 'puppet9' and platform is aix or solaris
   # Issue with Rubygems's SafeMarshal see: PA-8312
-  release_stream = ENV.fetch('RELEASE_STREAM')
+  release_stream = ENV.fetch('RELEASE_STREAM', nil)
   skip_platforms = /aix|solaris/i
   if release_stream == 'puppet9' && hosts.any? { |host| host['platform'] =~ skip_platforms }
     logger.info 'Skipping configure_gem_mirror for puppet9 on aix/solaris, issue with rubygems 4.0'


### PR DESCRIPTION
When running the task 'ci:test:setup' most users will not have
'RELEASE_STREAM' defined; this allows the task complete successfully
instead of raising a `KeyError: key not found` exception.